### PR TITLE
feat: currency verification

### DIFF
--- a/src/oracle/oracle.cairo
+++ b/src/oracle/oracle.cairo
@@ -1369,6 +1369,10 @@ mod Oracle {
             self.assert_only_admin();
             let check_pair = self.oracle_pairs_storage.read(new_pair.id);
             assert(check_pair.id == 0, 'Pair with this key registered');
+            let base_currency = self.oracle_currencies_storage.read(new_pair.base_currency_id);
+            assert(base_currency.id != 0, 'No base currency registered');
+            let quote_currency = self.oracle_currencies_storage.read(new_pair.quote_currency_id);
+            assert(quote_currency.id != 0, 'No quote currency registered');
             self.emit(Event::SubmittedPair(SubmittedPair { pair: new_pair }));
             self.oracle_pairs_storage.write(new_pair.id, new_pair);
             self

--- a/src/tests/test_oracle.cairo
+++ b/src/tests/test_oracle.cairo
@@ -822,15 +822,18 @@ fn test_get_last_checkpoint_before_should_fail_if_timestamp_too_old() {
 
 
 #[test]
-#[should_panic(expected: ('No base currency registered','ENTRYPOINT_FAILED' ))]
+#[should_panic(expected: ('No base currency registered', 'ENTRYPOINT_FAILED'))]
 #[available_gas(2000000000)]
 fn test_add_pair_should_panic_if_base_currency_do_not_corresponds() {
-    let (publisher_registry, oracle) = setup(); 
-    oracle.add_pair(Pair {
-                id: 10 ,
-                quote_currency_id: 111, 
-                base_currency_id: 1931029312,  //wrong base currency id 
-            })
+    let (publisher_registry, oracle) = setup();
+    oracle
+        .add_pair(
+            Pair {
+                id: 10,
+                quote_currency_id: 111,
+                base_currency_id: 1931029312, //wrong base currency id 
+            }
+        )
 }
 
 
@@ -838,10 +841,7 @@ fn test_add_pair_should_panic_if_base_currency_do_not_corresponds() {
 #[should_panic(expected: ('No quote currency registered', 'ENTRYPOINT_FAILED'))]
 #[available_gas(2000000000)]
 fn test_add_pair_should_panic_if_quote_currency_do_not_corresponds() {
-    let (publisher_registry, oracle) = setup(); 
-    oracle.add_pair(Pair {
-                id: 10 , 
-                quote_currency_id: 123123132,
-                base_currency_id: USD_CURRENCY_ID, 
-            })
+    let (publisher_registry, oracle) = setup();
+    oracle
+        .add_pair(Pair { id: 10, quote_currency_id: 123123132, base_currency_id: USD_CURRENCY_ID, })
 }

--- a/src/tests/test_oracle.cairo
+++ b/src/tests/test_oracle.cairo
@@ -820,3 +820,28 @@ fn test_get_last_checkpoint_before_should_fail_if_timestamp_too_old() {
         .get_last_checkpoint_before(DataType::SpotEntry(6), 111, AggregationMode::Median(()));
 }
 
+
+#[test]
+#[should_panic(expected: ('No base currency registered','ENTRYPOINT_FAILED' ))]
+#[available_gas(2000000000)]
+fn test_add_pair_should_panic_if_base_currency_do_not_corresponds() {
+    let (publisher_registry, oracle) = setup(); 
+    oracle.add_pair(Pair {
+                id: 10 ,
+                quote_currency_id: 111, 
+                base_currency_id: 1931029312,  //wrong base currency id 
+            })
+}
+
+
+#[test]
+#[should_panic(expected: ('No quote currency registered', 'ENTRYPOINT_FAILED'))]
+#[available_gas(2000000000)]
+fn test_add_pair_should_panic_if_quote_currency_do_not_corresponds() {
+    let (publisher_registry, oracle) = setup(); 
+    oracle.add_pair(Pair {
+                id: 10 , 
+                quote_currency_id: 123123132,
+                base_currency_id: USD_CURRENCY_ID, 
+            })
+}


### PR DESCRIPTION
Regarding the audit requirement:
  - Validate in add_pair that pair ids correspond to actual currencies