### PR TITLE
audit: separate function for pairwise

### DIFF
--- a/src/operations/time_series/structs.cairo
+++ b/src/operations/time_series/structs.cairo
@@ -12,10 +12,3 @@ struct List {
     arr: Array<u128>,
 }
 
-struct PAIRWISE_OPERATION {
-    ADDITION: (), // DEFAULT
-    SUBTRACTION: (),
-    MULTIPLICATION: (),
-    DIVISION: (),
-    FIXED_POINT_MULTIPLICATION: (),
-}


### PR DESCRIPTION
Since the function executes two different logics according to the type of the operation, the auditors suggested instead to implement two different functions in order to avoid control coupling (passing execution as parameters, for example, here realize the sub operation)