### PR TITLE
Randomness: Values check

### DIFF
--- a/src/randomness/example_randomness.cairo
+++ b/src/randomness/example_randomness.cairo
@@ -64,7 +64,11 @@ mod ExampleRandomness {
                     .try_into()
                     .unwrap()
             };
-            eth_dispatcher.approve(randomness_contract_address, callback_fee_limit.into());
+            eth_dispatcher
+                .approve(
+                    randomness_contract_address,
+                    (callback_fee_limit + callback_fee_limit / 5).into()
+                );
 
             // Request the randomness
             let randomness_dispatcher = IRandomnessDispatcher {

--- a/src/randomness/randomness.cairo
+++ b/src/randomness/randomness.cairo
@@ -245,7 +245,7 @@ mod Randomness {
             let token_dispatcher = ERC20CamelABIDispatcher { contract_address: token_address };
             // get the balance of the caller
             let user_balance = token_dispatcher.balanceOf(caller_address);
-            assert(user_balance > 0, Errors::INSUFFICIENT_BALANCE);
+            assert(user_balance != 0, Errors::INSUFFICIENT_BALANCE);
             // compute the premium fee
             let premium_fee = IRandomnessImpl::compute_premium_fee(@self, caller_address);
             let oracle_dispatcher = IOracleABIDispatcher {

--- a/src/randomness/randomness.cairo
+++ b/src/randomness/randomness.cairo
@@ -244,6 +244,7 @@ mod Randomness {
             let token_dispatcher = ERC20CamelABIDispatcher { contract_address: token_address };
             // get the balance of the caller
             let user_balance = token_dispatcher.balanceOf(caller_address);
+            assert(user_balance > 0, Errors::INSUFFICIENT_BALANCE);
             // compute the premium fee
             let premium_fee = IRandomnessImpl::compute_premium_fee(@self, caller_address);
             let oracle_dispatcher = IOracleABIDispatcher {

--- a/src/randomness/randomness.cairo
+++ b/src/randomness/randomness.cairo
@@ -127,6 +127,7 @@ mod Randomness {
         const REQUEST_NOT_RECEIVED: felt252 = 'request not received';
         const SAME_ADMIN_ADDRESS: felt252 = 'Same admin address';
         const ADMIN_ADDRESS_CANNOT_BE_ZERO: felt252 = 'Admin address cannot be zero';
+        const FETCHING_PRICE_ERROR: felt252 = 'Error fetching price';
     }
 
     #[derive(Drop, starknet::Event)]
@@ -251,7 +252,7 @@ mod Randomness {
                 contract_address: self.oracle_address.read()
             };
             let response = oracle_dispatcher.get_data_median(DataType::SpotEntry('ETH/USD'));
-
+            assert(response.price > 0, Errors::FETCHING_PRICE_ERROR);
             // Convert the premium fee in dollar to wei
             let wei_premium_fee = dollar_to_wei(premium_fee, response.price, response.decimals);
             // Check if the balance is greater than premium fee 


### PR DESCRIPTION
Small fixes for randomness contract: 

1. Check the price before realising the dollar to wei operation (avoid div(0))
2. Check if the user balance >0
3. In the example randomness contract, increase the approve amount in order to cover the callback fee liimit + functions fees