### PR TITLE
feat(oracle): change generic entry value type to u256

### DIFF
--- a/src/entry/structs.cairo
+++ b/src/entry/structs.cairo
@@ -44,7 +44,7 @@ struct SpotEntry {
 struct GenericEntry {
     base: BaseEntry,
     key: felt252,
-    value: u128,
+    value: u256,
 }
 
 #[derive(Copy, Drop, PartialOrd, Serde)]
@@ -245,7 +245,7 @@ impl FHasPriceImpl of HasPrice<FutureEntry> {
 
 impl GHasPriceImpl of HasPrice<GenericEntry> {
     fn get_price(self: @GenericEntry) -> u128 {
-        (*self).value
+        (*self).value.try_into().unwrap()
     }
 }
 impl ResponseHasPriceImpl of HasPrice<PragmaPricesResponse> {

--- a/src/oracle/oracle.cairo
+++ b/src/oracle/oracle.cairo
@@ -1002,7 +1002,7 @@ mod Oracle {
                                 timestamp: _entry.timestamp, source: source, publisher: publisher
                             },
                             key: key,
-                            value: _entry.price
+                            value: _entry.price.into()
                         }
                     )
                 }
@@ -1132,7 +1132,7 @@ mod Oracle {
                                 timestamp: last_updated_timestamp, source: source, publisher: 0
                             },
                             key: key,
-                            value: median
+                            value: median.into()
                         }
                     );
                 }
@@ -1448,7 +1448,7 @@ mod Oracle {
                     let element = EntryStorage {
                         timestamp: generic_entry.base.timestamp,
                         volume: 0,
-                        price: generic_entry.value,
+                        price: generic_entry.value.try_into().unwrap(),
                     };
                     set_entry_storage(
                         ref self,

--- a/src/tests/test_oracle.cairo
+++ b/src/tests/test_oracle.cairo
@@ -446,6 +446,7 @@ fn test_get_data() {
     let entry = oracle.get_data(DataType::FutureEntry((5, 11111110)), AggregationMode::Median(()));
     assert(entry.price == (5 * 1000000), 'wrong price');
 }
+
 fn data_treatment(entry: PossibleEntries) -> (u128, u64, u128) {
     match entry {
         PossibleEntries::Spot(entry) => {
@@ -456,10 +457,11 @@ fn data_treatment(entry: PossibleEntries) -> (u128, u64, u128) {
             (entry.price, entry.base.timestamp, entry.volume)
         },
         PossibleEntries::Generic(entry) => {
-            (entry.value, entry.base.timestamp, 0)
+            (entry.value.try_into().unwrap(), entry.base.timestamp, 0)
         }
     }
 }
+
 #[test]
 #[available_gas(10000000000)]
 fn test_get_admin_address() {


### PR DESCRIPTION
## Changes

Change the `value` type of `GenericEntry` to u256.

## Important note

It will panic if one tries to run an aggregation endpoint on a generic entry that takes up more than a `u128`. This change is only meant to allow generic entries to be used for merkle feeds.

For context, merkle feeds are a type of data feeds where only the merkle root is submitted on-chain. Data feed consumers then need a merkle proof to access the underlying data.