### PR TITLE
feat: conversion rate price for tokenized vaults

### DIFF
--- a/pragma-oracle/src/entry/entry.cairo
+++ b/pragma-oracle/src/entry/entry.cairo
@@ -44,6 +44,11 @@ mod Entry {
                 let value: u128 = entries_mean(entries);
                 value
             },
+            AggregationMode::ConversionRate => {
+                panic_with_felt252('No agg for conversion rate');
+                // No aggregation needed for conversion rate
+                0
+            },
             AggregationMode::Error(()) => {
                 panic_with_felt252('Wrong aggregation mode');
                 0

--- a/pragma-oracle/src/entry/structs.cairo
+++ b/pragma-oracle/src/entry/structs.cairo
@@ -180,10 +180,11 @@ struct PragmaPricesResponse {
     expiration_timestamp: Option<u64>,
 }
 
-#[derive(Serde, Drop, Copy, starknet::Store)]
+#[derive(Serde, Drop, Copy, starknet::Store, PartialEq)]
 enum AggregationMode {
     Median: (),
     Mean: (),
+    ConversionRate,
     Error: (),
 }
 
@@ -306,6 +307,7 @@ impl AggregationModeIntoU8 of TryInto<AggregationMode, u8> {
         match self {
             AggregationMode::Median(()) => Option::Some(0_u8),
             AggregationMode::Mean(()) => Option::Some(1_u8),
+            AggregationMode::ConversionRate => Option::Some(2_u8),
             AggregationMode::Error(()) => Option::None(()),
         }
     }
@@ -316,6 +318,8 @@ impl u8IntoAggregationMode of Into<u8, AggregationMode> {
             AggregationMode::Median(())
         } else if self == 1_u8 {
             AggregationMode::Mean(())
+        } else if self == 2_u8 {
+            AggregationMode::ConversionRate
         } else {
             AggregationMode::Error(())
         }

--- a/pragma-oracle/src/erc4626/erc4626.cairo
+++ b/pragma-oracle/src/erc4626/erc4626.cairo
@@ -1,116 +1,186 @@
 // Forked from https://github.com/0xEniotna/ERC4626/blob/main/src/erc4626/interface.cairo
+// Mock contract to be used for TESTING PURPOSE ONLY
 use starknet::ContractAddress;
 
 #[starknet::interface]
-trait IERC4626<TState> {
-    // ************************************
-    // * Metadata
-    // ************************************
-    fn name(self: @TState) -> felt252;
-    fn symbol(self: @TState) -> felt252;
-    fn decimals(self: @TState) -> u8;
+trait IERC4626<TContractState> {
+    // Metadata (match implementation)
+    fn name(self: @TContractState) -> felt252;
+    fn symbol(self: @TContractState) -> felt252;
+    fn decimals(self: @TContractState) -> u8;
 
-    // ************************************
-    // * snake_case
-    // ************************************
-    fn total_supply(self: @TState) -> u256;
-    fn balance_of(self: @TState, account: ContractAddress) -> u256;
-    fn allowance(self: @TState, owner: ContractAddress, spender: ContractAddress) -> u256;
-    fn transfer(ref self: TState, recipient: ContractAddress, amount: u256) -> bool;
+    // ERC20-like methods (match implementation)
+    fn total_supply(self: @TContractState) -> u256;
+    fn balance_of(self: @TContractState, account: ContractAddress) -> u256;
+    fn allowance(self: @TContractState, owner: ContractAddress, spender: ContractAddress) -> u256;
+    fn transfer(ref self: TContractState, recipient: ContractAddress, amount: u256) -> bool;
     fn transfer_from(
-        ref self: TState, sender: ContractAddress, recipient: ContractAddress, amount: u256
+        ref self: TContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256
     ) -> bool;
-    fn approve(ref self: TState, spender: ContractAddress, amount: u256) -> bool;
+    fn approve(ref self: TContractState, spender: ContractAddress, amount: u256) -> bool;
 
-    // ************************************
-    // * camelCase
-    // ************************************
-    fn totalSupply(self: @TState) -> u256;
-    fn balanceOf(self: @TState, account: ContractAddress) -> u256;
-    fn transferFrom(
-        ref self: TState, sender: ContractAddress, recipient: ContractAddress, amount: u256
-    ) -> bool;
+    // Remove camelCase methods as they're not in the implementation
 
-    // ************************************
-    // * Additional functions
-    // ************************************
-    fn asset(self: @TState) -> starknet::ContractAddress;
-    fn convert_to_assets(self: @TState, shares: u256) -> u256;
-    fn convert_to_shares(self: @TState, assets: u256) -> u256;
-    fn deposit(ref self: TState, assets: u256, receiver: starknet::ContractAddress) -> u256;
-    fn max_deposit(self: @TState, address: starknet::ContractAddress) -> u256;
-    fn max_mint(self: @TState, receiver: starknet::ContractAddress) -> u256;
-    fn max_redeem(self: @TState, owner: starknet::ContractAddress) -> u256;
-    fn max_withdraw(self: @TState, owner: starknet::ContractAddress) -> u256;
-    fn mint(ref self: TState, shares: u256, receiver: starknet::ContractAddress) -> u256;
-    fn preview_deposit(self: @TState, assets: u256) -> u256;
-    fn preview_mint(self: @TState, shares: u256) -> u256;
-    fn preview_redeem(self: @TState, shares: u256) -> u256;
-    fn preview_withdraw(self: @TState, assets: u256) -> u256;
-    fn redeem(
-        ref self: TState,
-        shares: u256,
-        receiver: starknet::ContractAddress,
-        owner: starknet::ContractAddress
-    ) -> u256;
-    fn total_assets(self: @TState) -> u256;
+    // Additional ERC4626 methods (match implementation)
+    fn asset(self: @TContractState) -> ContractAddress;
+    fn total_assets(self: @TContractState) -> u256;
+    fn convert_to_shares(self: @TContractState, assets: u256) -> u256;
+    fn convert_to_assets(self: @TContractState, shares: u256) -> u256;
+    fn max_deposit(self: @TContractState, receiver: ContractAddress) -> u256;
+    fn preview_deposit(self: @TContractState, assets: u256) -> u256;
+    fn deposit(ref self: TContractState, assets: u256, receiver: ContractAddress) -> u256;
+    fn max_mint(self: @TContractState, receiver: ContractAddress) -> u256;
+    fn preview_mint(self: @TContractState, shares: u256) -> u256;
+    fn mint(ref self: TContractState, shares: u256, receiver: ContractAddress) -> u256;
+    fn max_withdraw(self: @TContractState, owner: ContractAddress) -> u256;
+    fn preview_withdraw(self: @TContractState, assets: u256) -> u256;
     fn withdraw(
-        ref self: TState,
-        assets: u256,
-        receiver: starknet::ContractAddress,
-        owner: starknet::ContractAddress
+        ref self: TContractState, assets: u256, receiver: ContractAddress, owner: ContractAddress
     ) -> u256;
-}
-
-
-#[starknet::interface]
-trait IERC4626Metadata<TState> {
-    fn name(self: @TState) -> felt252;
-    fn symbol(self: @TState) -> felt252;
-    fn decimals(self: @TState) -> u8;
-}
-
-#[starknet::interface]
-trait IERC4626Camel<TState> {
-    fn totalSupply(self: @TState) -> u256;
-    fn balanceOf(self: @TState, account: ContractAddress) -> u256;
-    fn transferFrom(
-        ref self: TState, sender: ContractAddress, recipient: ContractAddress, amount: u256
-    ) -> bool;
-}
-
-#[starknet::interface]
-trait IERC4626Snake<TState> {
-    fn total_supply(self: @TState) -> u256;
-    fn balance_of(self: @TState, account: ContractAddress) -> u256;
-    fn allowance(self: @TState, owner: ContractAddress, spender: ContractAddress) -> u256;
-    fn transfer(ref self: TState, recipient: ContractAddress, amount: u256) -> bool;
-    fn transfer_from(
-        ref self: TState, sender: ContractAddress, recipient: ContractAddress, amount: u256
-    ) -> bool;
-    fn approve(ref self: TState, spender: ContractAddress, amount: u256) -> bool;
-}
-
-#[starknet::interface]
-trait IERC4626Additional<TState> {
-    fn asset(self: @TState) -> ContractAddress;
-    fn convert_to_assets(self: @TState, shares: u256) -> u256;
-    fn convert_to_shares(self: @TState, assets: u256) -> u256;
-    fn deposit(ref self: TState, assets: u256, receiver: ContractAddress) -> u256;
-    fn max_deposit(self: @TState, address: ContractAddress) -> u256;
-    fn max_mint(self: @TState, receiver: ContractAddress) -> u256;
-    fn max_redeem(self: @TState, owner: ContractAddress) -> u256;
-    fn max_withdraw(self: @TState, owner: ContractAddress) -> u256;
-    fn mint(ref self: TState, shares: u256, receiver: ContractAddress) -> u256;
-    fn preview_deposit(self: @TState, assets: u256) -> u256;
-    fn preview_mint(self: @TState, shares: u256) -> u256;
-    fn preview_redeem(self: @TState, shares: u256) -> u256;
-    fn preview_withdraw(self: @TState, assets: u256) -> u256;
+    fn max_redeem(self: @TContractState, owner: ContractAddress) -> u256;
+    fn preview_redeem(self: @TContractState, shares: u256) -> u256;
     fn redeem(
-        ref self: TState, shares: u256, receiver: ContractAddress, owner: ContractAddress
+        ref self: TContractState, shares: u256, receiver: ContractAddress, owner: ContractAddress
     ) -> u256;
-    fn total_assets(self: @TState) -> u256;
-    fn withdraw(
-        ref self: TState, assets: u256, receiver: ContractAddress, owner: ContractAddress
-    ) -> u256;
+}
+
+#[starknet::contract]
+mod ERC4626 {
+    use super::IERC4626;
+    use starknet::get_caller_address;
+    use starknet::get_contract_address;
+    use starknet::ContractAddress;
+    use starknet::contract_address::ContractAddressZeroable;
+    use zeroable::Zeroable;
+    use traits::Into;
+    use traits::TryInto;
+    use option::OptionTrait;
+    use integer::BoundedInt;
+    use debug::PrintTrait;
+
+    #[storage]
+    struct Storage {}
+
+    #[external(v0)]
+    impl ERC4626Impl of IERC4626<ContractState> {
+        ////////////////////////////////
+        // ERC20 implementation
+        ////////////////////////////////
+
+        fn name(self: @ContractState) -> felt252 {
+            0
+        }
+
+        fn symbol(self: @ContractState) -> felt252 {
+            0
+        }
+
+        fn decimals(self: @ContractState) -> u8 {
+            0
+        }
+
+        fn total_supply(self: @ContractState) -> u256 {
+            0
+        }
+
+        fn balance_of(self: @ContractState, account: ContractAddress) -> u256 {
+            0
+        }
+
+        fn allowance(
+            self: @ContractState, owner: ContractAddress, spender: ContractAddress
+        ) -> u256 {
+            0
+        }
+
+        fn transfer(ref self: ContractState, recipient: ContractAddress, amount: u256) -> bool {
+            true
+        }
+
+        fn transfer_from(
+            ref self: ContractState,
+            sender: ContractAddress,
+            recipient: ContractAddress,
+            amount: u256
+        ) -> bool {
+            true
+        }
+
+        fn approve(ref self: ContractState, spender: ContractAddress, amount: u256) -> bool {
+            true
+        }
+
+        ////////////////////////////////
+        // ERC4626-specific implementation
+        ////////////////////////////////
+
+        fn asset(self: @ContractState) -> ContractAddress {
+            0.try_into().unwrap()
+        }
+
+        fn total_assets(self: @ContractState) -> u256 {
+            0
+        }
+
+        fn convert_to_shares(self: @ContractState, assets: u256) -> u256 {
+            0
+        }
+
+        fn convert_to_assets(self: @ContractState, shares: u256) -> u256 {
+            0
+        }
+
+        fn max_deposit(self: @ContractState, receiver: ContractAddress) -> u256 {
+            0
+        }
+
+        fn preview_deposit(self: @ContractState, assets: u256) -> u256 {
+            0
+        }
+
+        fn deposit(ref self: ContractState, assets: u256, receiver: ContractAddress) -> u256 {
+            0
+        }
+
+        fn max_mint(self: @ContractState, receiver: ContractAddress) -> u256 {
+            BoundedInt::<u256>::max()
+        }
+
+        fn preview_mint(self: @ContractState, shares: u256) -> u256 {
+            // TESTING
+            1002465544733197129
+        }
+
+        fn mint(ref self: ContractState, shares: u256, receiver: ContractAddress) -> u256 {
+            0
+        }
+
+        fn max_withdraw(self: @ContractState, owner: ContractAddress) -> u256 {
+            0
+        }
+
+        fn preview_withdraw(self: @ContractState, assets: u256) -> u256 {
+            0
+        }
+
+        fn withdraw(
+            ref self: ContractState, assets: u256, receiver: ContractAddress, owner: ContractAddress
+        ) -> u256 {
+            0
+        }
+
+        fn max_redeem(self: @ContractState, owner: ContractAddress) -> u256 {
+            0
+        }
+
+        fn preview_redeem(self: @ContractState, shares: u256) -> u256 {
+            0
+        }
+
+        fn redeem(
+            ref self: ContractState, shares: u256, receiver: ContractAddress, owner: ContractAddress
+        ) -> u256 {
+            0
+        }
+    }
 }

--- a/pragma-oracle/src/erc4626/erc4626.cairo
+++ b/pragma-oracle/src/erc4626/erc4626.cairo
@@ -1,0 +1,116 @@
+// Forked from https://github.com/0xEniotna/ERC4626/blob/main/src/erc4626/interface.cairo
+use starknet::ContractAddress;
+
+#[starknet::interface]
+trait IERC4626<TState> {
+    // ************************************
+    // * Metadata
+    // ************************************
+    fn name(self: @TState) -> felt252;
+    fn symbol(self: @TState) -> felt252;
+    fn decimals(self: @TState) -> u8;
+
+    // ************************************
+    // * snake_case
+    // ************************************
+    fn total_supply(self: @TState) -> u256;
+    fn balance_of(self: @TState, account: ContractAddress) -> u256;
+    fn allowance(self: @TState, owner: ContractAddress, spender: ContractAddress) -> u256;
+    fn transfer(ref self: TState, recipient: ContractAddress, amount: u256) -> bool;
+    fn transfer_from(
+        ref self: TState, sender: ContractAddress, recipient: ContractAddress, amount: u256
+    ) -> bool;
+    fn approve(ref self: TState, spender: ContractAddress, amount: u256) -> bool;
+
+    // ************************************
+    // * camelCase
+    // ************************************
+    fn totalSupply(self: @TState) -> u256;
+    fn balanceOf(self: @TState, account: ContractAddress) -> u256;
+    fn transferFrom(
+        ref self: TState, sender: ContractAddress, recipient: ContractAddress, amount: u256
+    ) -> bool;
+
+    // ************************************
+    // * Additional functions
+    // ************************************
+    fn asset(self: @TState) -> starknet::ContractAddress;
+    fn convert_to_assets(self: @TState, shares: u256) -> u256;
+    fn convert_to_shares(self: @TState, assets: u256) -> u256;
+    fn deposit(ref self: TState, assets: u256, receiver: starknet::ContractAddress) -> u256;
+    fn max_deposit(self: @TState, address: starknet::ContractAddress) -> u256;
+    fn max_mint(self: @TState, receiver: starknet::ContractAddress) -> u256;
+    fn max_redeem(self: @TState, owner: starknet::ContractAddress) -> u256;
+    fn max_withdraw(self: @TState, owner: starknet::ContractAddress) -> u256;
+    fn mint(ref self: TState, shares: u256, receiver: starknet::ContractAddress) -> u256;
+    fn preview_deposit(self: @TState, assets: u256) -> u256;
+    fn preview_mint(self: @TState, shares: u256) -> u256;
+    fn preview_redeem(self: @TState, shares: u256) -> u256;
+    fn preview_withdraw(self: @TState, assets: u256) -> u256;
+    fn redeem(
+        ref self: TState,
+        shares: u256,
+        receiver: starknet::ContractAddress,
+        owner: starknet::ContractAddress
+    ) -> u256;
+    fn total_assets(self: @TState) -> u256;
+    fn withdraw(
+        ref self: TState,
+        assets: u256,
+        receiver: starknet::ContractAddress,
+        owner: starknet::ContractAddress
+    ) -> u256;
+}
+
+
+#[starknet::interface]
+trait IERC4626Metadata<TState> {
+    fn name(self: @TState) -> felt252;
+    fn symbol(self: @TState) -> felt252;
+    fn decimals(self: @TState) -> u8;
+}
+
+#[starknet::interface]
+trait IERC4626Camel<TState> {
+    fn totalSupply(self: @TState) -> u256;
+    fn balanceOf(self: @TState, account: ContractAddress) -> u256;
+    fn transferFrom(
+        ref self: TState, sender: ContractAddress, recipient: ContractAddress, amount: u256
+    ) -> bool;
+}
+
+#[starknet::interface]
+trait IERC4626Snake<TState> {
+    fn total_supply(self: @TState) -> u256;
+    fn balance_of(self: @TState, account: ContractAddress) -> u256;
+    fn allowance(self: @TState, owner: ContractAddress, spender: ContractAddress) -> u256;
+    fn transfer(ref self: TState, recipient: ContractAddress, amount: u256) -> bool;
+    fn transfer_from(
+        ref self: TState, sender: ContractAddress, recipient: ContractAddress, amount: u256
+    ) -> bool;
+    fn approve(ref self: TState, spender: ContractAddress, amount: u256) -> bool;
+}
+
+#[starknet::interface]
+trait IERC4626Additional<TState> {
+    fn asset(self: @TState) -> ContractAddress;
+    fn convert_to_assets(self: @TState, shares: u256) -> u256;
+    fn convert_to_shares(self: @TState, assets: u256) -> u256;
+    fn deposit(ref self: TState, assets: u256, receiver: ContractAddress) -> u256;
+    fn max_deposit(self: @TState, address: ContractAddress) -> u256;
+    fn max_mint(self: @TState, receiver: ContractAddress) -> u256;
+    fn max_redeem(self: @TState, owner: ContractAddress) -> u256;
+    fn max_withdraw(self: @TState, owner: ContractAddress) -> u256;
+    fn mint(ref self: TState, shares: u256, receiver: ContractAddress) -> u256;
+    fn preview_deposit(self: @TState, assets: u256) -> u256;
+    fn preview_mint(self: @TState, shares: u256) -> u256;
+    fn preview_redeem(self: @TState, shares: u256) -> u256;
+    fn preview_withdraw(self: @TState, assets: u256) -> u256;
+    fn redeem(
+        ref self: TState, shares: u256, receiver: ContractAddress, owner: ContractAddress
+    ) -> u256;
+    fn total_assets(self: @TState) -> u256;
+    fn withdraw(
+        ref self: TState, assets: u256, receiver: ContractAddress, owner: ContractAddress
+    ) -> u256;
+}

--- a/pragma-oracle/src/lib.cairo
+++ b/pragma-oracle/src/lib.cairo
@@ -9,6 +9,9 @@ mod utils {
     mod bitwise;
     mod strings;
 }
+mod erc4626 {
+    mod erc4626;
+}
 mod operations {
     mod sorting {
         mod merge_sort;

--- a/pragma-oracle/src/oracle/oracle.cairo
+++ b/pragma-oracle/src/oracle/oracle.cairo
@@ -101,6 +101,9 @@ trait IOracleABI<TContractState> {
     );
     fn remove_source(ref self: TContractState, source: felt252, data_type: DataType) -> bool;
     fn set_sources_threshold(ref self: TContractState, threshold: u32);
+    fn register_tokenized_vault(
+        ref self: TContractState, token: felt252, token_address: ContractAddress
+    );
     fn upgrade(ref self: TContractState, impl_hash: ClassHash);
 }
 
@@ -192,6 +195,7 @@ mod Oracle {
         IPublisherRegistryABIDispatcher, IPublisherRegistryABIDispatcherTrait
     };
     use starknet::{get_block_timestamp, Felt252TryIntoContractAddress};
+    use pragma::erc4626::erc4626::{IERC4626Dispatcher, IERC4626DispatcherTrait};
 
     use cmp::{max, min};
     use option::OptionTrait;
@@ -235,6 +239,8 @@ mod Oracle {
         //oracle_checkpoint_index, legacyMap between (pair_id, (SPOT/FUTURES/OPTIONS), expiration_timestamp (0 for SPOT)) and the index of the last checkpoint
         oracle_checkpoint_index: LegacyMap::<(felt252, felt252, u64, u8), u64>,
         oracle_sources_threshold_storage: u32,
+        // registry containing registered tokenized vaults and the corresponding address
+        tokenized_vault: LegacyMap<(felt252, felt252), ContractAddress>
     }
 
 
@@ -514,18 +520,56 @@ mod Oracle {
         }
 
         // @notice aggregate all the entries for a given data type, with a given aggregation mode
+        // @notice The aggregation mode `ConversionRate` is set for tokenized vault, with pricing made based on STRK price and associated conversion rate fetched 
+        // @notice onchain. 
         // @param data_type: an enum of DataType (e.g : DataType::SpotEntry(ASSET_ID) or DataType::FutureEntry((ASSSET_ID, expiration_timestamp)))
         // @param aggregation_mode: the aggregation method to be used (e.g. AggregationMode::Median(()))
         // @returns a PragmaPricesResponse, a structure providing the main information for an asset (see entry/structs for details)
         fn get_data(
             self: @ContractState, data_type: DataType, aggregation_mode: AggregationMode
         ) -> PragmaPricesResponse {
-            let sources = IOracleABI::get_all_sources(self, data_type);
-            let prices_response: PragmaPricesResponse = IOracleABI::get_data_for_sources(
-                self, data_type, aggregation_mode, sources
-            );
+            if aggregation_mode == AggregationMode::ConversionRate {
+                // Query median for STRK/USD
+                let sources = IOracleABI::get_all_sources(self, DataType::SpotEntry('STRK/USD'));
+                let response: PragmaPricesResponse = IOracleABI::get_data_for_sources(
+                    self, DataType::SpotEntry('STRK/USD'), AggregationMode::Median(()), sources
+                );
 
-            prices_response
+                //  Extract base asset
+                let asset: felt252 = match data_type {
+                    DataType::SpotEntry(asset) => asset,
+                    DataType::FutureEntry(_) => panic_with_felt252('Set only for Spot entries'),
+                    DataType::GenericEntry(_) => panic_with_felt252('Set only for Spot entries'),
+                };
+
+                // Get base currency and pool
+                let base_asset: felt252 = self.get_pair(asset).base_currency_id;
+                assert(base_asset != 0, 'Asset not registered');
+                let pool_address: ContractAddress = self.tokenized_vault.read((base_asset, 'STRK'));
+                assert(
+                    pool_address != contract_address_const::<0>(), 'No pool address for given token'
+                );
+                let pool = IERC4626Dispatcher { contract_address: pool_address };
+
+                // Compute adjusted price
+                let price: u256 = response.price.into()
+                    * pool.preview_mint(1000000000000000000)
+                    / 1000000000000000000;
+
+                // The conversion should not fail because we scaled the price to 8 decimals
+                let converted_price: u128 = price.try_into().expect('Conversion should not fail');
+                assert(converted_price != 0, 'Price conversion failed');
+                PragmaPricesResponse {
+                    price: converted_price,
+                    decimals: response.decimals,
+                    last_updated_timestamp: response.last_updated_timestamp,
+                    num_sources_aggregated: response.num_sources_aggregated,
+                    expiration_timestamp: response.expiration_timestamp
+                }
+            } else {
+                let sources = IOracleABI::get_all_sources(self, data_type);
+                IOracleABI::get_data_for_sources(self, data_type, aggregation_mode, sources)
+            }
         }
 
         // @notice aggregate all the entries for a given data type and given sources, with a given aggregation mode
@@ -1770,6 +1814,22 @@ mod Oracle {
                 }
             }
         }
+
+        // @notice register a new tokenized vault into the regisry (priced with STRK)
+        // @dev Callable only by the owner
+        // @dev the token must be registered as currency and pair in the oracle registry
+        // @dev We reserve the owner of the contract the right to overwrite an existing token address
+        // @param token The token to register
+        // @param token_address Token address to register
+        fn register_tokenized_vault(
+            ref self: ContractState, token: felt252, token_address: ContractAddress
+        ) {
+            OracleInternal::assert_only_admin();
+            assert(token != 0, 'Token cannot be 0');
+            assert(token_address != contract_address_const::<0>(), 'Token address cannot be 0');
+            self.tokenized_vault.write((token, 'STRK'), token_address)
+        }
+
 
         // @notice set a new checkpoint for a given data type and and aggregation mode
         // @param data_type: an enum of DataType (e.g : DataType::SpotEntry(ASSET_ID) or DataType::FutureEntry((ASSSET_ID, expiration_timestamp)))

--- a/pragma-oracle/src/oracle/oracle.cairo
+++ b/pragma-oracle/src/oracle/oracle.cairo
@@ -105,6 +105,7 @@ trait IOracleABI<TContractState> {
     fn register_tokenized_vault(
         ref self: TContractState, token: felt252, token_address: ContractAddress
     );
+    fn delete_tokenized_vault(ref self: TContractState, token: felt252);
     fn upgrade(ref self: TContractState, impl_hash: ClassHash);
 }
 
@@ -1839,6 +1840,18 @@ mod Oracle {
                 'Token address cannot be 0'
             );
             self.tokenized_vault.write((token, 'STRK'), token_address)
+        }
+
+        // @notice delete a registered tokenized vault 
+        // @dev Callable only by the admin
+        // @param token The token to be removed
+        fn delete_tokenized_vault(ref self: ContractState, token: felt252) {
+            OracleInternal::assert_only_admin();
+            assert(token != 0, 'Token cannot be 0');
+
+            let token_address = self.tokenized_vault.read((token, 'STRK'));
+            assert(token_address != starknet::contract_address_const::<0>(), 'Already deleted');
+            self.tokenized_vault.write((token, 'STRK'), starknet::contract_address_const::<0>());
         }
 
 

--- a/pragma-oracle/src/tests/test_oracle.cairo
+++ b/pragma-oracle/src/tests/test_oracle.cairo
@@ -1530,7 +1530,7 @@ fn test_get_conversion_rate_price_fails_if_asset_not_registered() {
         .add_currency(
             Currency {
                 id: 'STRK',
-                decimals: 18,
+                decimals: 8,
                 is_abstract_currency: false,
                 starknet_address: 0.try_into().unwrap(),
                 ethereum_address: 0.try_into().unwrap(),
@@ -1540,7 +1540,7 @@ fn test_get_conversion_rate_price_fails_if_asset_not_registered() {
         .add_currency(
             Currency {
                 id: 'xSTRK',
-                decimals: 18,
+                decimals: 8,
                 is_abstract_currency: false,
                 starknet_address: 0.try_into().unwrap(),
                 ethereum_address: 0.try_into().unwrap(),

--- a/pragma-oracle/src/tests/test_oracle.cairo
+++ b/pragma-oracle/src/tests/test_oracle.cairo
@@ -11,6 +11,7 @@ use starknet::class_hash::class_hash_const;
 use traits::Into;
 use traits::TryInto;
 use pragma::oracle::oracle::Oracle;
+use pragma::erc4626::erc4626::ERC4626;
 use pragma::oracle::oracle::{IOracleABIDispatcher, IOracleABIDispatcherTrait};
 use pragma::publisher_registry::publisher_registry::{
     IPublisherRegistryABIDispatcher, IPublisherRegistryABIDispatcherTrait
@@ -318,6 +319,14 @@ fn setup() -> (IPublisherRegistryABIDispatcher, IOracleABIDispatcher) {
         );
 
     (publisher_registry, oracle)
+}
+
+fn deploy_erc4626() -> ContractAddress {
+    let (erc4626_address, _) = deploy_syscall(
+        ERC4626::TEST_CLASS_HASH.try_into().unwrap(), 0, array![].span(), true
+    )
+        .unwrap_syscall();
+    return erc4626_address;
 }
 #[test]
 #[available_gas(200000000000000)]
@@ -1370,4 +1379,78 @@ fn test_update_pair() {
     assert(pair.id == 1, 'wrong pair fetched');
     assert(pair.quote_currency_id == 111, 'wrong recorded pair');
     assert(pair.base_currency_id == 12345, 'wrong recorded pair');
+}
+
+
+#[test]
+#[available_gas(20000000000000)]
+fn test_register_tokenized_vault() {
+    let (publisher_registry, oracle) = setup();
+    let token: felt252 = 'xStrk';
+    let token_address: ContractAddress = contract_address_const::<0x12345566>();
+    let admin = contract_address_const::<0x123456789>();
+    set_contract_address(admin);
+    oracle.register_tokenized_vault(token, token_address);
+    assert(oracle.get_tokenized_vaults(token) == token_address, 'Failed to register token');
+}
+
+
+#[test]
+#[available_gas(20000000000000)]
+#[should_panic(expected: ('Admin: unauthorized', 'ENTRYPOINT_FAILED'))]
+fn test_register_tokenized_vault_panics_if_not_owner() {
+    let (publisher_registry, oracle) = setup();
+    let token: felt252 = 'xStrk';
+    let token_address: ContractAddress = contract_address_const::<0x12345566>();
+    set_contract_address(contract_address_const::<0x12>());
+    oracle.register_tokenized_vault(token, token_address);
+}
+
+
+#[test]
+#[available_gas(20000000000000)]
+fn test_get_conversion_rate_price() {
+    let now = 100000;
+    let (publisher_registry, oracle) = setup();
+    let admin = contract_address_const::<0x123456789>();
+    set_contract_address(admin);
+    oracle
+        .add_currency(
+            Currency {
+                id: 'STRK',
+                decimals: 8,
+                is_abstract_currency: false,
+                starknet_address: 0.try_into().unwrap(),
+                ethereum_address: 0.try_into().unwrap(),
+            }
+        );
+    oracle
+        .add_currency(
+            Currency {
+                id: 'xSTRK',
+                decimals: 8,
+                is_abstract_currency: false,
+                starknet_address: 0.try_into().unwrap(),
+                ethereum_address: 0.try_into().unwrap(),
+            }
+        );
+    oracle.add_pair(Pair { id: 'STRK/USD', base_currency_id: 'STRK', quote_currency_id: 'USD', });
+    oracle.add_pair(Pair { id: 'xSTRK/USD', base_currency_id: 'xSTRK', quote_currency_id: 'USD', });
+    oracle
+        .publish_data(
+            PossibleEntries::Spot(
+                SpotEntry {
+                    base: BaseEntry { timestamp: now, source: 2, publisher: 1 },
+                    pair_id: 'STRK/USD',
+                    price: 68250000,
+                    volume: 0
+                }
+            )
+        );
+    let erc4626 = deploy_erc4626();
+    oracle.register_tokenized_vault('xSTRK', erc4626);
+    let res = oracle.get_data(DataType::SpotEntry('xSTRK/USD'), AggregationMode::ConversionRate);
+    assert(
+        res.price == (68250000 * 1002465544733197129) / 1000000000000000000, 'Computation failed'
+    );
 }

--- a/pragma-oracle/src/tests/test_oracle.cairo
+++ b/pragma-oracle/src/tests/test_oracle.cairo
@@ -1394,6 +1394,23 @@ fn test_register_tokenized_vault() {
     assert(oracle.get_tokenized_vaults(token) == token_address, 'Failed to register token');
 }
 
+#[test]
+#[available_gas(20000000000000)]
+fn test_delete_tokenized_vault() {
+    let (publisher_registry, oracle) = setup();
+    let token: felt252 = 'xStrk';
+    let token_address: ContractAddress = contract_address_const::<0x12345566>();
+    let admin = contract_address_const::<0x123456789>();
+    set_contract_address(admin);
+    oracle.register_tokenized_vault(token, token_address);
+    assert(oracle.get_tokenized_vaults(token) == token_address, 'Failed to register token');
+    oracle.delete_tokenized_vault(token);
+    assert(
+        oracle.get_tokenized_vaults(token) == contract_address_const::<0>(),
+        'Failed to delete token'
+    );
+}
+
 
 #[test]
 #[available_gas(20000000000000)]


### PR DESCRIPTION
## Addition

 - A new aggregation mode, available only for LST based on STRK. 
 - Modified `get_data` function to handle the ConversionRate case. 
 - New storage slot for registered LST token addresses
 - `add` and `remove` LST token address
 - Tests 