### PR TITLE
feat: conversion rate as feed

### DIFF
--- a/pragma-oracle/src/oracle/oracle.cairo
+++ b/pragma-oracle/src/oracle/oracle.cairo
@@ -105,6 +105,8 @@ trait IOracleABI<TContractState> {
     fn register_tokenized_vault(
         ref self: TContractState, token: felt252, token_address: ContractAddress
     );
+    fn get_registered_conversion_rate_pairs(self: @TContractState) -> Span<felt252>;
+    fn add_registered_conversion_rate_pair(ref self: TContractState, new_pair_id: felt252);
     fn upgrade(ref self: TContractState, impl_hash: ClassHash);
 }
 
@@ -1675,6 +1677,19 @@ mod Oracle {
         // @returns the Pair struct associated
         fn get_pair(self: @ContractState, pair_id: felt252) -> Pair {
             self.oracle_pairs_storage.read(pair_id)
+        }
+
+        // @notice retrieve the list of registered conversion rate pairs
+        // @returns List of registered conversion rate pairs
+        fn get_registered_conversion_rate_pairs(self: @ContractState) -> Span<felt252> {
+            self.conversion_rate_compatible_pairs.read().array().span()
+        }
+
+        // @notice add a new pair to the list of registered conversion rate pairs
+        // @param new_pair_id: the pair id to be added
+        fn add_registered_conversion_rate_pair(ref self: ContractState, new_pair_id: felt252) {
+            let mut registered_pairs = self.conversion_rate_compatible_pairs.read();
+            registered_pairs.append(new_pair_id);
         }
 
 

--- a/pragma-oracle/src/oracle/oracle.cairo
+++ b/pragma-oracle/src/oracle/oracle.cairo
@@ -2440,7 +2440,10 @@ mod Oracle {
         }
     }
 
-
+    // @notice computes the conversion rate price for a given data type 
+    // @dev the conversion rate is computed by querying the median of the STRK/USD pair and then scaling the price to the quote asset
+    // @param data_type : the data type to consider
+    // @returns a PragmaPricesResponse (see entry/structs) 
     fn get_conversion_rate_price(
         self: @ContractState, data_type: DataType
     ) -> PragmaPricesResponse {

--- a/pragma-oracle/src/oracle/oracle.cairo
+++ b/pragma-oracle/src/oracle/oracle.cairo
@@ -540,11 +540,7 @@ mod Oracle {
                 DataType::GenericEntry(pair_id) => pair_id,
             };
 
-            let registered_conversion_rate_pairs = self
-                .conversion_rate_compatible_pairs
-                .read()
-                .array()
-                .span();
+            let registered_conversion_rate_pairs = self.get_registered_conversion_rate_pairs();
             if registered_conversion_rate_pairs.contains(pair_id)
                 || aggregation_mode == AggregationMode::ConversionRate {
                 get_conversion_rate_price(self, data_type)


### PR DESCRIPTION
## Addition 

- We've added support for creating conversion rate feeds. To use this feature, first register the conversion rate quote pair ID in the whitelist registry. Once registered, the feed will become available.

## Breaking changes

While there are no breaking changes, we have added two new lines of code outside the if statement. We need to ensure these additions don't affect the get_data function:

- The first line extracts the pair ID from the data type, which should work reliably.
- The second line retrieves the stored conversion rate pair ID and converts it to a span. This operation should work safely, even with an empty list.